### PR TITLE
add servable editing to service

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -452,6 +452,18 @@ def get_namespaces():
     return json.dumps(res)
 
 
+@api.route("/servables/<servable_namespace>/<servable_name>", methods=['POST'])
+def api_edit_servable(servable_namespace, servable_name):
+    """
+    Edit a servable
+
+    Args:
+        servable_namespace (str): Namespace of servable
+        servable_name (str): Name of the servable
+    """
+    pass
+
+
 @api.route("/servables/<servable_namespace>/<servable_name>", methods=['DELETE'])
 def api_delete_servable(servable_namespace, servable_name):
     """


### PR DESCRIPTION
Not ready to be merged yet, remains untested. The DLHub SDK has a corresponding [update](https://github.com/DLHub-Argonne/dlhub_sdk/pull/161) that adds the method for calling this route. Considerations for deleting servables are also included, but the `delete_servable` function is not yet implemented on the SDK.