### PR TITLE
Scripts to manage (re)starting and running the webservice outside of the

### DIFF
--- a/gunicorn_log_to_file.sh
+++ b/gunicorn_log_to_file.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+source activate dlhub
+source /home/ubuntu/dlhub.sh
+
+NAME="DLHub"
+FLASKDIR=/home/ubuntu/dlhub_service
+SOCKFILE=/home/ubuntu/dlhub_service/dlhub.sock
+USER=ubuntu
+GROUP=ubuntu
+NUM_WORKERS=3
+KEY_FILE=/home/ubuntu/dlhub_service/config/key.pem
+CERT_FILE=/home/ubuntu/dlhub_service/config/cert.pem
+ACCESSLOG=/home/ubuntu/dlhub_service/dlhub_access_log
+ERRORLOG=/home/ubuntu/dlhub_service/dlhub_error_log
+PIDFILE=/home/ubuntu/dlhub_service/dlhub_web_service.pid
+
+echo "Starting $NAME"
+if test -f "$PIDFILE"; then
+    PID=$(<$PIDFILE)
+    if test -d /proc/$PID; then
+        echo "DLHub Web Service Process already running"
+        exit
+    else
+        rm $PIDFILE
+    fi
+fi
+
+#Get env variables
+#set -o allexport
+#source /home/ubuntu/env.cfg
+#set +o allexport
+
+# Create the run directory if it doesn't exist
+RUNDIR=$(dirname $SOCKFILE)
+test -d $RUNDIR || mkdir -p $RUNDIR
+
+#record PID 
+echo "$$" > $PIDFILE
+
+# Start your gunicorn
+exec gunicorn run:app -b 0.0.0.0:8080 \
+  --name $NAME \
+  --workers $NUM_WORKERS \
+  --certfile $CERT_FILE \
+  --keyfile $KEY_FILE \
+  --user=$USER --group=$GROUP \
+  --bind=unix:$SOCKFILE \
+  --timeout 900 \
+  --access-logfile $ACCESSLOG \
+  --error-logfile $ERRORLOG \
+  --capture-output

--- a/restart_dlhub_webservice.sh
+++ b/restart_dlhub_webservice.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+PIDFILE=/home/ubuntu/dlhub_service/dlhub_web_service.pid
+FLASKDIR=/home/ubuntu/dlhub_service
+
+cd $FLASKDIR
+
+if test -f "$PIDFILE"; then
+    PID=$(<$PIDFILE)
+    if test -d /proc/$PID; then
+        kill $PID
+        sleep 10
+        ./gunicorn_log_to_file.sh >& /dev/null &
+    else
+        ./gunicorn_log_to_file.sh >& /dev/null &
+    fi
+fi
+
+


### PR DESCRIPTION
screen shell

No changes to anything existing, just a little work around how to (re)start the webservice so it can happen from a crontab.